### PR TITLE
allow shift+click for movement in mapeditor and shift+drag for rotation ...

### DIFF
--- a/src/map-editor/js/MapEditor.js
+++ b/src/map-editor/js/MapEditor.js
@@ -91,7 +91,7 @@ GS.MapEditor.prototype = {
 	initModifyOriginEvent: function() {
 		var that = this;
 		$(document).mousemove(function(e) {
-			if (GS.InputHelper.middleMouseDown) {
+			if (GS.InputHelper.middleMouseDown || (GS.InputHelper.leftMouseDown && GS.InputHelper.shift)) {
 				var mx = GS.InputHelper.mouseX;
 				var my = GS.InputHelper.mouseY;
 				var dx = (mx - that.ox);

--- a/src/voxel-editor/js/VoxelEditor.js
+++ b/src/voxel-editor/js/VoxelEditor.js
@@ -68,7 +68,7 @@ GS.VoxelEditor.prototype = {
 		this.controls.distance = 8;
 		this.controls.minDistance = 4;
 		this.controls.maxDistance = 32;
-		this.controls.mouseDownProperty = "middleMouseDown";
+		this.controls.mouseDownProperty = "shift";
 		this.controls.canvasSelector = "#voxel-canvas";
 
 		this.controls.init();


### PR DESCRIPTION
...in voxel editor:

fixes #19 

note that this breaks middle-mouse rotation in voxel editor, but it's a net gain.